### PR TITLE
Catch Exceptions thrown by HCL2

### DIFF
--- a/tests/aws_iam_policy_document_parse_error.tf
+++ b/tests/aws_iam_policy_document_parse_error.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "example" {
+  statement {
+    sid = "1"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "${concat(
+          list(
+            module.test_1.role_arn,
+            module.test_2.role_arn,
+            module.test_2.role_arn,
+          ),
+          formatlist("arn:aws:iam::${local.account}:user/%s", concat(
+            list("Test1", "Test2"),
+            list("Test3", "Test4"),
+          ))
+        )}",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "example" {
+  name   = "example_policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.example.json}"
+}

--- a/tf-parliament.py
+++ b/tf-parliament.py
@@ -2,6 +2,7 @@
 import argparse
 import glob
 import hcl2
+import lark
 import os
 import re
 import json
@@ -80,8 +81,11 @@ def mock_iam_statement_from_tf(statement_data):
 
 
 def validate_file(filename):
-    with(open(filename, 'r')) as file:
-        tf = hcl2.load(file)
+    try:
+        with(open(filename, 'r')) as file:
+            tf = hcl2.load(file)
+    except lark.exceptions.UnexpectedToken as e:
+        return [parliament.finding.Finding("Failed to parse file", str(e), filename)]
 
     findings = []
 


### PR DESCRIPTION
HCL2 is not able to parse all IAM Policy Documents, as
some Terraform statements can be quite elaborate. Simply
catch Exceptions thrown by HCL2 and package them as a
Parliament finding.

This prevents the entire analysis to be broken off by
tf-parliament, and the caller can decide to consider if
the error is a problem or not.