### PR TITLE
Catch empty IAM Policy Documents

### DIFF
--- a/tests/aws_iam_policy_document_empty.tf
+++ b/tests/aws_iam_policy_document_empty.tf
@@ -1,0 +1,10 @@
+data "aws_iam_policy_document" "empty" {
+  source_json   = "${data.aws_iam_policy_document.source.json}"
+  override_json = "${data.aws_iam_policy_document.override.json}"
+}
+
+resource "aws_iam_policy" "example" {
+  name   = "example_policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.example.json}"
+}


### PR DESCRIPTION
It is possible to create IAM Policy Documents without statements,
as it could be a combination of `source_json` and `override_json`.
Catch this situation by checking if the `statement` key is present
in the object.