### PR TITLE
#172379251 Allow Using a Parliament Config Override File

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.7.6-alpine3.10
 WORKDIR /bin
-COPY * /bin/
+COPY requirements.txt /bin/
 RUN pip install -r requirements.txt
 RUN mkdir -p /github/workspace/
+COPY * /bin/
 WORKDIR /github/workspace/
 ENTRYPOINT ["/bin/tf-parliament.py"]
 CMD ["."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ COPY * /bin/
 WORKDIR /github/workspace/
 ENTRYPOINT ["/bin/tf-parliament.py"]
 CMD ["."]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ docopt==0.6.2
 docutils==0.15.2
 jmespath==0.9.4
 lark-parser==0.7.8
-parliament==0.3.7
+parliament==0.4.12
 python-dateutil==2.8.1
 python-hcl2==0.2.2
 PyYAML==5.3


### PR DESCRIPTION
This change adds a `--config` option to specify a parliament configuration override file.
I needed this to change the reporting for select alerts.

The addition `--config-is-optional` switch can be used to have this run in a script etc. traversing directories, where the configuration file might not be present on purpose. If the switch is set, no error will be thrown.