### PR TITLE
Include Sid field for findings

### DIFF
--- a/tf-parliament.py
+++ b/tf-parliament.py
@@ -22,6 +22,7 @@ policy_template = """{{
 }}"""
 
 field_mappings = [
+    {'tf_key': 'sid', 'iam_key': 'Sid', 'mock_value': ''},
     {'tf_key': 'effect', 'iam_key': 'Effect', 'mock_value': 'Allow'},
     {'tf_key': 'actions', 'iam_key': 'Action', 'mock_value': '*'},
     {'tf_key': 'not_actions', 'iam_key': 'NotAction', 'mock_value': '*'},


### PR DESCRIPTION
This field can also fail late (at terraform apply time) if it's not formatted correctly and Parliament can warn about this - it just needs including in your field mappings.

Tested manually on:
```
data "aws_iam_policy_document" "example" {
    statement {
        sid = "foo bar"
        actions = [
            "s3:GetObject",
        ]
        resources = [
            "arn:aws:s3:::mybucket/*",
        ]
    }
}
```

```
test.tf
INVALID_SID
Details:
  {'Effect': 'Allow', 'Sid': 'foo bar', 'Action': ['s3:GetObject'], 'Resource': ['arn:aws:s3:::mybucket/*']}
Location:
  {'filepath': None}
```